### PR TITLE
#276 scenario restoration

### DIFF
--- a/experiment/esm-scen7-h-aer.json
+++ b/experiment/esm-scen7-h-aer.json
@@ -1,0 +1,35 @@
+{
+    "id": "esm-scen7-h-aer",
+    "validation-key": "esm-scen7-h-Aer",
+    "ui-label": "Future scenario esm-scen7-h with high aerosol emissions",
+    "description": "1. Detailed experiment configuration Future scenario esm-scen7-h with higher aerosol emissions  2. Required model settings We encourage modelling centres to include as much atmospheric composition capability as possible. As a minimum, models should have prescribed or interactive aerosols. And the experimental setup should be consistent with other scenario experiments.  3. Experiment conditions  4. Links to relevant references Fiedler et al. (in prep.) AerChemMIP2 - Unraveling the role of reactive gases, aerosols, and land use for air quality and climate change in CMIP7  5. Similarities to CMIP6 experiments None  6. Forcing differences from parent experiment Increased aerosol emissions compared to parent.",
+    "activity": [
+        "aerchemmip"
+    ],
+    "alias": [],
+    "minimum-number-of-years": "104",
+    "model-realms": [
+        {
+            "id": "aer",
+            "is-required": true
+        },
+        {
+            "id": "aogcm",
+            "is-required": true
+        },
+        {
+            "id": "chem",
+            "is-required": false
+        }
+    ],
+    "parent-experiment": [
+        "esm-hist"
+    ],
+    "start-date": "2022",
+    "tier": "1",
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/esm-scen7-h-aq.json
+++ b/experiment/esm-scen7-h-aq.json
@@ -1,0 +1,35 @@
+{
+    "id": "esm-scen7-h-aq",
+    "validation-key": "esm-scen7-h-AQ",
+    "ui-label": "Future scenario esm-scen7-h with high aerosol and tropospheric non-methane ozone precursor emissions",
+    "description": "1. Detailed experiment configuration Future scenario esm-scen7-h with higher aerosol and tropospheric non-methane ozone precursor emissions  2. Required model settings We encourage modelling centres to include as much atmospheric composition capability as possible. But, as a minimum, models should have tropospheric chemistry and interactive aerosols. And the experimental setup should be consistent with other scenario experiments.   3. Experiment conditions  4. Links to relevant references Fiedler et al. (in prep.) AerChemMIP2 - Unraveling the role of reactive gases, aerosols, and land use for air quality and climate change in CMIP7   5. Similarities to CMIP6 experiments None  6. Forcing differences from parent experiment Increased aerosol and tropospheric non-methane ozone precursor emissions compared to parent.",
+    "activity": [
+        "aerchemmip"
+    ],
+    "alias": [],
+    "minimum-number-of-years": "104",
+    "model-realms": [
+        {
+            "id": "aer",
+            "is-required": true
+        },
+        {
+            "id": "aogcm",
+            "is-required": true
+        },
+        {
+            "id": "chem",
+            "is-required": true
+        }
+    ],
+    "parent-experiment": [
+        "esm-hist"
+    ],
+    "start-date": "none",
+    "tier": "1",
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/esm-scen7-h-ext-os.json
+++ b/experiment/esm-scen7-h-ext-os.json
@@ -1,0 +1,24 @@
+{
+    "id": "esm-scen7-h-ext-os",
+    "validation-key": "esm-scen7-h-ext-os",
+    "ui-label": "High Scenario Overshoot Extension",
+    "description": "High emission scenario overshoot extension to explore potential high-end impacts",
+    "activity": [
+        "scenariomip"
+    ],
+    "alias": [],
+    "end": 2500,
+    "min-number-yrs-per-sim": 50,
+    "model-realms": [],
+    "parent-experiment": [
+        "esm-scen7-h"
+    ],
+    "start": 2101,
+    "start-date": "none",
+    "tier": 0,
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/esm-scen7-h-ext.json
+++ b/experiment/esm-scen7-h-ext.json
@@ -1,0 +1,24 @@
+{
+    "id": "esm-scen7-h-ext",
+    "validation-key": "esm-scen7-h-ext",
+    "ui-label": "High Scenario Extension",
+    "description": "High emission scenario extension to explore potential high-end impacts",
+    "activity": [
+        "scenariomip"
+    ],
+    "alias": [],
+    "end": 2500,
+    "min-number-yrs-per-sim": 50,
+    "model-realms": [],
+    "parent-experiment": [
+        "esm-scen7-h"
+    ],
+    "start": 2101,
+    "start-date": "none",
+    "tier": 0,
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/esm-scen7-h.json
+++ b/experiment/esm-scen7-h.json
@@ -1,0 +1,24 @@
+{
+    "id": "esm-scen7-h",
+    "validation-key": "esm-scen7-h",
+    "ui-label": "High Scenario",
+    "description": "High emission scenario to explore potential high-end impacts",
+    "activity": [
+        "scenariomip"
+    ],
+    "alias": [],
+    "end": 2100,
+    "min-number-yrs-per-sim": 79,
+    "model-realms": [],
+    "parent-experiment": [
+        "esm-hist"
+    ],
+    "start": 2022,
+    "start-date": "none",
+    "tier": 0,
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/esm-scen7-l-ext.json
+++ b/experiment/esm-scen7-l-ext.json
@@ -1,0 +1,24 @@
+{
+    "id": "esm-scen7-l-ext",
+    "validation-key": "esm-scen7-l-ext",
+    "ui-label": "Low Scenario Extension",
+    "description": "Scenario extension consistent with staying likely below 2 degrees C",
+    "activity": [
+        "scenariomip"
+    ],
+    "alias": [],
+    "end": 2500,
+    "min-number-yrs-per-sim": 50,
+    "model-realms": [],
+    "parent-experiment": [
+        "esm-scen7-l"
+    ],
+    "start": 2101,
+    "start-date": "none",
+    "tier": 0,
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/esm-scen7-l.json
+++ b/experiment/esm-scen7-l.json
@@ -1,0 +1,24 @@
+{
+    "id": "esm-scen7-l",
+    "validation-key": "esm-scen7-l",
+    "ui-label": "Low Scenario",
+    "description": "Scenario consistent with staying likely below 2 degrees C",
+    "activity": [
+        "scenariomip"
+    ],
+    "alias": [],
+    "end": 2100,
+    "min-number-yrs-per-sim": 79,
+    "model-realms": [],
+    "parent-experiment": [
+        "esm-hist"
+    ],
+    "start": 2022,
+    "start-date": "none",
+    "tier": 0,
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/esm-scen7-ln-aer.json
+++ b/experiment/esm-scen7-ln-aer.json
@@ -1,0 +1,31 @@
+{
+    "id": "esm-scen7-ln-aer",
+    "validation-key": "esm-scen7-ln-Aer",
+    "ui-label": "Future scenario esm-scen7-ln  with high aerosol emissions",
+    "description": "1. Detailed experiment configuration Future scenario esm-scen7-ln with higher aerosol emissions  2. Required model settings We encourage modelling centres to include as much atmospheric composition capability as possible. As a minimum, models should have prescribed or interactive aerosols. And the experimental setup should be consistent with other scenario experiments.   3. Experiment conditions  4. Links to relevant references Fiedler et al. (in prep.) AerChemMIP2 - Unraveling the role of reactive gases, aerosols, and land use for air quality and climate change in CMIP7  5. Similarities to CMIP6 experiments None  6. Forcing differences from parent experiment Increased aerosol emissions compared to parent.",
+    "activity": [
+        "aerchemmip"
+    ],
+    "alias": [],
+    "minimum-number-of-years": "104",
+    "model-realms": [
+        {
+            "id": "aer",
+            "is-required": true
+        },
+        {
+            "id": "aogcm",
+            "is-required": true
+        }
+    ],
+    "parent-experiment": [
+        "esm-hist"
+    ],
+    "start-date": "none",
+    "tier": "1",
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/esm-scen7-ln-aq.json
+++ b/experiment/esm-scen7-ln-aq.json
@@ -1,0 +1,35 @@
+{
+    "id": "esm-scen7-ln-aq",
+    "validation-key": "esm-scen7-vlho-AQ",
+    "ui-label": "Future scenario esm-scen7-ln with high aerosol and tropospheric non-methane ozone precursor emissions",
+    "description": "1. Detailed experiment configuration Future scenario esm-scen7-ln with higher aerosol and tropospheric non-methane ozone precursor emissions  2. Required model settings We encourage modelling centres to include as much atmospheric composition capability as possible. But, as a minimum, models should have tropospheric chemistry and interactive aerosols. And the experimental setup should be consistent with other scenario experiments.  3. Experiment conditions  4. Links to relevant references Fiedler et al. (in prep.) AerChemMIP2 - Unraveling the role of reactive gases, aerosols, and land use for air quality and climate change in CMIP7  5. Similarities to CMIP6 experiments none  6. Forcing differences from parent experiment Increased aerosol and ozone precursor emissions compared to parent.",
+    "activity": [
+        "aerchemmip"
+    ],
+    "alias": [],
+    "minimum-number-of-years": "104",
+    "model-realms": [
+        {
+            "id": "aer",
+            "is-required": true
+        },
+        {
+            "id": "aogcm",
+            "is-required": true
+        },
+        {
+            "id": "chem",
+            "is-required": true
+        }
+    ],
+    "parent-experiment": [
+        "esm-hist"
+    ],
+    "start-date": "2022",
+    "tier": "1",
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/esm-scen7-ln-ext.json
+++ b/experiment/esm-scen7-ln-ext.json
@@ -1,0 +1,24 @@
+{
+    "id": "esm-scen7-ln-ext",
+    "validation-key": "esm-scen7-ln-ext",
+    "ui-label": "Very Low Scenario with Limited Overshoot Extension",
+    "description": "Extension to scenario with similar end-of-century temperature impact to VL, but with less aggressive near-term mitigation and large reliance on net negative emissions, resulting in a higher overshoot.",
+    "activity": [
+        "scenariomip"
+    ],
+    "alias": [],
+    "end": 2500,
+    "min-number-yrs-per-sim": 50,
+    "model-realms": [],
+    "parent-experiment": [
+        "esm-scen7-ln"
+    ],
+    "start": 2101,
+    "start-date": "none",
+    "tier": 0,
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/esm-scen7-ln.json
+++ b/experiment/esm-scen7-ln.json
@@ -1,0 +1,24 @@
+{
+    "id": "esm-scen7-ln",
+    "validation-key": "esm-scen7-ln",
+    "ui-label": "Very Low Scenario after High Overshoot",
+    "description": "Scenario with similar endof-century temperature impact to VL, but with less aggressive near-term mitigation and large reliance on net negative emissions, resulting in a higher overshoot.",
+    "activity": [
+        "scenariomip"
+    ],
+    "alias": [],
+    "end": 2100,
+    "min-number-yrs-per-sim": 79,
+    "model-realms": [],
+    "parent-experiment": [
+        "esm-hist"
+    ],
+    "start": 2022,
+    "start-date": "none",
+    "tier": 0,
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/esm-scen7-m-ext.json
+++ b/experiment/esm-scen7-m-ext.json
@@ -1,0 +1,24 @@
+{
+    "id": "esm-scen7-m-ext",
+    "validation-key": "esm-scen7-m-ext",
+    "ui-label": "Medium Scenario Extension",
+    "description": "Medium emission scenario extension consistent with current policies",
+    "activity": [
+        "scenariomip"
+    ],
+    "alias": [],
+    "end": 2500,
+    "min-number-yrs-per-sim": 50,
+    "model-realms": [],
+    "parent-experiment": [
+        "esm-scen7-m"
+    ],
+    "start": 2101,
+    "start-date": "none",
+    "tier": 0,
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/esm-scen7-m.json
+++ b/experiment/esm-scen7-m.json
@@ -1,0 +1,24 @@
+{
+    "id": "esm-scen7-m",
+    "validation-key": "esm-scen7-m",
+    "ui-label": "Medium Scenario",
+    "description": "Medium emission scenario consistent with current policies",
+    "activity": [
+        "scenariomip"
+    ],
+    "alias": [],
+    "end": 2100,
+    "min-number-yrs-per-sim": 79,
+    "model-realms": [],
+    "parent-experiment": [
+        "esm-hist"
+    ],
+    "start": 2022,
+    "start-date": "none",
+    "tier": 0,
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/esm-scen7-ml-ext.json
+++ b/experiment/esm-scen7-ml-ext.json
@@ -1,0 +1,24 @@
+{
+    "id": "esm-scen7-ml-ext",
+    "validation-key": "esm-scen7-ml-ext",
+    "ui-label": "Medium Low Scenario Extension",
+    "description": "Extension to scenario with delayed increase in mitigation effort, insufficient to meet Paris Agreement objectives",
+    "activity": [
+        "scenariomip"
+    ],
+    "alias": [],
+    "end": 2500,
+    "min-number-yrs-per-sim": 50,
+    "model-realms": [],
+    "parent-experiment": [
+        "esm-scen7-ml"
+    ],
+    "start": 2101,
+    "start-date": "none",
+    "tier": 0,
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/esm-scen7-ml.json
+++ b/experiment/esm-scen7-ml.json
@@ -1,0 +1,24 @@
+{
+    "id": "esm-scen7-ml",
+    "validation-key": "esm-scen7-ml",
+    "ui-label": "Medium-Low Scenario",
+    "description": "Scenario with delayed increase in mitigation effort, insufficient to meet Paris Agreement objectives",
+    "activity": [
+        "scenariomip"
+    ],
+    "alias": [],
+    "end": 2100,
+    "min-number-yrs-per-sim": 79,
+    "model-realms": [],
+    "parent-experiment": [
+        "esm-hist"
+    ],
+    "start": 2022,
+    "start-date": "none",
+    "tier": 0,
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/esm-scen7-vl-ext.json
+++ b/experiment/esm-scen7-vl-ext.json
@@ -1,0 +1,24 @@
+{
+    "id": "esm-scen7-vl-ext",
+    "validation-key": "esm-scen7-vl-ext",
+    "ui-label": "Very Low Scenario with Limited Overshoot Extension",
+    "description": "Extension to scenario consistent with limiting warming to 1.5 degree C by 2100 AD with limited overshoot (as low as plausible) of 1.5 degree C",
+    "activity": [
+        "scenariomip"
+    ],
+    "alias": [],
+    "end": 2500,
+    "min-number-yrs-per-sim": 50,
+    "model-realms": [],
+    "parent-experiment": [
+        "esm-scen7-vl"
+    ],
+    "start": 2101,
+    "start-date": "none",
+    "tier": 0,
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/esm-scen7-vl.json
+++ b/experiment/esm-scen7-vl.json
@@ -1,0 +1,24 @@
+{
+    "id": "esm-scen7-vl",
+    "validation-key": "esm-scen7-vl",
+    "ui-label": "Very Low Scenario with Limited Overshoot",
+    "description": "Scenario consistent with limiting warming to 1.5 degree C by 2100 AD with limited overshoot (as low as plausible) of 1.5 degree C",
+    "activity": [
+        "scenariomip"
+    ],
+    "alias": [],
+    "end": 2100,
+    "min-number-yrs-per-sim": 79,
+    "model-realms": [],
+    "parent-experiment": [
+        "esm-hist"
+    ],
+    "start": 2022,
+    "start-date": "none",
+    "tier": 0,
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/highres-future-scen7-m.json
+++ b/experiment/highres-future-scen7-m.json
@@ -1,0 +1,39 @@
+{
+    "id": "highres-future-scen7-m",
+    "validation-key": "highres-future-scen7-m",
+    "ui-label": "Coupled future medium scenario",
+    "description": "HighResMIP2 Tier 2: highres-future-scen7-m  Conduct coupled future projection simulations (present-2100) initialized from the end of the hist-1950 simulation, using scenario forcing. scen7-m is the CMIP7 scenario (medium is recommended)  For further details, please refer to: Roberts, M. J., Reed, K. A., Bao, Q., Barsugli, J. J., Camargo, S. J., Caron, L. P., … & Zhao, M. (2025). High-Resolution Model Intercomparison Project phase 2 (HighResMIP2) towards CMIP7. Geoscientific Model Development, 18, 1307–1332  [High-Resolution Model Intercomparison Project Phase 2 (HighResMIP2) towards CMIP7.pdf](https://github.com/user-attachments/files/19401230/High-Resolution.Model.Intercomparison.Project.Phase.2.HighResMIP2.towards.CMIP7.pdf)  Webpage: https://highresmip.org/experiments/experiment_cmip7/",
+    "activity": [
+        "highresmip"
+    ],
+    "alias": [],
+    "minimum-number-of-years": "78",
+    "model-realms": [
+        {
+            "id": "aogcm",
+            "is-required": true
+        },
+        {
+            "id": "aer",
+            "is-required": false
+        },
+        {
+            "id": "bgc",
+            "is-required": false
+        },
+        {
+            "id": "chem",
+            "is-required": false
+        }
+    ],
+    "parent-experiment": [
+        "none"
+    ],
+    "start-date": "1950-01-01",
+    "tier": "2",
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/highres-future-scen7-m.json
+++ b/experiment/highres-future-scen7-m.json
@@ -2,7 +2,7 @@
     "id": "highres-future-scen7-m",
     "validation-key": "highres-future-scen7-m",
     "ui-label": "High resolution coupled future medium scenario",
-    "description": "HighResMIP2 Tier 2: highres-future-scen7-m  Conduct coupled future projection simulations (present-2100) initialized from the end of the hist-1950 simulation, using scenario forcing. scen7-m is the CMIP7 scenario (medium is recommended)  For further details, please refer to: Roberts, M. J., Reed, K. A., Bao, Q., Barsugli, J. J., Camargo, S. J., Caron, L. P., … & Zhao, M. (2025). High-Resolution Model Intercomparison Project phase 2 (HighResMIP2) towards CMIP7. Geoscientific Model Development, 18, 1307–1332  [High-Resolution Model Intercomparison Project Phase 2 (HighResMIP2) towards CMIP7.pdf](https://github.com/user-attachments/files/19401230/High-Resolution.Model.Intercomparison.Project.Phase.2.HighResMIP2.towards.CMIP7.pdf)  Webpage: https://highresmip.org/experiments/experiment_cmip7/",
+    "description": "HighResMIP2 Tier 2: highres-future-scen7-m. Conduct coupled future projection simulations (present-2100) initialized from the end of the hist-1950 simulation, using scenario forcing from the CMIP7 medium scenario (`scen7-m`). For further details, please refer to: Roberts, M. J., Reed, K. A., Bao, Q., Barsugli, J. J., Camargo, S. J., Caron, L. P., … & Zhao, M. (2025). High-Resolution Model Intercomparison Project phase 2 (HighResMIP2) towards CMIP7. Geoscientific Model Development, 18, 1307–1332. Webpage: https://highresmip.org/experiments/experiment_cmip7/",
     "activity": [
         "highresmip"
     ],

--- a/experiment/highres-future-scen7-m.json
+++ b/experiment/highres-future-scen7-m.json
@@ -1,7 +1,7 @@
 {
     "id": "highres-future-scen7-m",
     "validation-key": "highres-future-scen7-m",
-    "ui-label": "Coupled future medium scenario",
+    "ui-label": "High resolution coupled future medium scenario",
     "description": "HighResMIP2 Tier 2: highres-future-scen7-m  Conduct coupled future projection simulations (present-2100) initialized from the end of the hist-1950 simulation, using scenario forcing. scen7-m is the CMIP7 scenario (medium is recommended)  For further details, please refer to: Roberts, M. J., Reed, K. A., Bao, Q., Barsugli, J. J., Camargo, S. J., Caron, L. P., … & Zhao, M. (2025). High-Resolution Model Intercomparison Project phase 2 (HighResMIP2) towards CMIP7. Geoscientific Model Development, 18, 1307–1332  [High-Resolution Model Intercomparison Project Phase 2 (HighResMIP2) towards CMIP7.pdf](https://github.com/user-attachments/files/19401230/High-Resolution.Model.Intercomparison.Project.Phase.2.HighResMIP2.towards.CMIP7.pdf)  Webpage: https://highresmip.org/experiments/experiment_cmip7/",
     "activity": [
         "highresmip"

--- a/experiment/scen7-h-aer.json
+++ b/experiment/scen7-h-aer.json
@@ -1,0 +1,35 @@
+{
+    "id": "scen7-h-aer",
+    "validation-key": "scen7-h-Aer",
+    "ui-label": "Future scenario scen7-h with high aerosol emissions",
+    "description": "1. Detailed experiment configuration Future scenario scen7-hc with higher aerosol emissions  2. Required model settings We encourage modelling centres to include as much atmospheric composition capability as possible. As a minimum, models should have prescribed or interactive aerosols. And the experimental setup should be consistent with other scenario experiments.  3. Experiment conditions  4. Links to relevant references Fiedler et al. (in prep.) AerChemMIP2 - Unraveling the role of reactive gases, aerosols, and land use for air quality and climate change in CMIP7  5. Similarities to CMIP6 experiments None  6. Forcing differences from parent experiment Increased aerosol emissions compared to parent.",
+    "activity": [
+        "aerchemmip"
+    ],
+    "alias": [],
+    "minimum-number-of-years": "104",
+    "model-realms": [
+        {
+            "id": "aer",
+            "is-required": true
+        },
+        {
+            "id": "aogcm",
+            "is-required": true
+        },
+        {
+            "id": "chem",
+            "is-required": false
+        }
+    ],
+    "parent-experiment": [
+        "historical"
+    ],
+    "start-date": "2022",
+    "tier": "1",
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/scen7-h-aq.json
+++ b/experiment/scen7-h-aq.json
@@ -1,0 +1,35 @@
+{
+    "id": "scen7-h-aq",
+    "validation-key": "scen7-h-AQ",
+    "ui-label": "Future scenario scen7-h with high aerosol and tropospheric non-methane ozone precursor emissions",
+    "description": "1. Detailed experiment configuration Future scenario scen7-hc with higher aerosol and tropospheric non-methane ozone precursor emissions  2. Required model settings We encourage modelling centres to include as much atmospheric composition capability as possible. But, as a minimum, models should have tropospheric chemistry and interactive aerosols. And the experimental setup should be consistent with other scenario experiments.  3.  Experiment conditions  4. Links to relevant references Fiedler et al. (in prep.) AerChemMIP2 - Unraveling the role of reactive gases, aerosols, and land use for air quality and climate change in CMIP7  5. Similarities to CMIP6 experiments None  6. Forcing differences from parent experiment Increased aerosol and tropospheric non-methane ozone precursor emissions compared to parent.",
+    "activity": [
+        "aerchemmip"
+    ],
+    "alias": [],
+    "minimum-number-of-years": "104",
+    "model-realms": [
+        {
+            "id": "aer",
+            "is-required": true
+        },
+        {
+            "id": "aogcm",
+            "is-required": true
+        },
+        {
+            "id": "chem",
+            "is-required": true
+        }
+    ],
+    "parent-experiment": [
+        "historical"
+    ],
+    "start-date": "2022",
+    "tier": "1",
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/scen7-h-ext-os.json
+++ b/experiment/scen7-h-ext-os.json
@@ -1,0 +1,24 @@
+{
+    "id": "scen7-h-ext-os",
+    "validation-key": "scen7-h-ext-os",
+    "ui-label": "High, Concentration Driven Scenario Overshoot Extension",
+    "description": "High concentration driven emission scenario overshoot extension to explore potential high-end impacts",
+    "activity": [
+        "scenariomip"
+    ],
+    "alias": [],
+    "end": 2500,
+    "min-number-yrs-per-sim": 50,
+    "model-realms": [],
+    "parent-experiment": [
+        "scen7-h"
+    ],
+    "start": 2101,
+    "start-date": "none",
+    "tier": 0,
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/scen7-h-ext.json
+++ b/experiment/scen7-h-ext.json
@@ -1,0 +1,24 @@
+{
+    "id": "scen7-h-ext",
+    "validation-key": "scen7-h-ext",
+    "ui-label": "High, Concentration Driven Scenario Extension",
+    "description": "High concentration driven emission scenario extension to explore potential high-end impacts",
+    "activity": [
+        "scenariomip"
+    ],
+    "alias": [],
+    "end": 2500,
+    "min-number-yrs-per-sim": 50,
+    "model-realms": [],
+    "parent-experiment": [
+        "scen7-h"
+    ],
+    "start": 2101,
+    "start-date": "none",
+    "tier": 0,
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/scen7-h.json
+++ b/experiment/scen7-h.json
@@ -1,0 +1,24 @@
+{
+    "id": "scen7-h",
+    "validation-key": "scen7-h",
+    "ui-label": "High, Concentration Driven Scenario",
+    "description": "High concentration driven emission scenario to explore potential high-end impacts",
+    "activity": [
+        "scenariomip"
+    ],
+    "alias": [],
+    "end": 2100,
+    "min-number-yrs-per-sim": 79,
+    "model-realms": [],
+    "parent-experiment": [
+        "historical"
+    ],
+    "start": 2022,
+    "start-date": "none",
+    "tier": 0,
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/scen7-l-ext.json
+++ b/experiment/scen7-l-ext.json
@@ -1,0 +1,24 @@
+{
+    "id": "scen7-l-ext",
+    "validation-key": "scen7-l-ext",
+    "ui-label": "Low, Concentration Driven Scenario Extension",
+    "description": "Extension to concentration driven scenario consistent with staying likely below 2 degrees C",
+    "activity": [
+        "scenariomip"
+    ],
+    "alias": [],
+    "end": 2500,
+    "min-number-yrs-per-sim": 50,
+    "model-realms": [],
+    "parent-experiment": [
+        "scen7-l"
+    ],
+    "start": 2101,
+    "start-date": "none",
+    "tier": 0,
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/scen7-l.json
+++ b/experiment/scen7-l.json
@@ -1,0 +1,24 @@
+{
+    "id": "scen7-l",
+    "validation-key": "scen7-l",
+    "ui-label": "Low, Concentration Driven Scenario",
+    "description": "Concentration driven scenario consistent with staying likely below 2 degrees C",
+    "activity": [
+        "scenariomip"
+    ],
+    "alias": [],
+    "end": 2100,
+    "min-number-yrs-per-sim": 79,
+    "model-realms": [],
+    "parent-experiment": [
+        "historical"
+    ],
+    "start": 2022,
+    "start-date": "none",
+    "tier": 0,
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/scen7-ln-aer.json
+++ b/experiment/scen7-ln-aer.json
@@ -1,0 +1,31 @@
+{
+    "id": "scen7-ln-aer",
+    "validation-key": "scen7-ln-Aer",
+    "ui-label": "Future scenario scen7-ln with high aerosol emissions",
+    "description": "1. Detailed experiment configuration Future scenario scen7-vlhoc with higher aerosol emissions  2 . Required model settings We encourage modelling centres to include as much atmospheric composition capability as possible. As a minimum, models should have prescribed or interactive aerosols. And the experimental setup should be consistent with other scenario experiments.  3. Experiment conditions  4. Links to relevant references Fiedler et al. (in prep.) AerChemMIP2 - Unraveling the role of reactive gases, aerosols, and land use for air quality and climate change in CMIP7  5. Similarities to CMIP6 experiments None  6. Forcing differences from parent experiment Increased aerosol emissions compared to parent.",
+    "activity": [
+        "aerchemmip"
+    ],
+    "alias": [],
+    "minimum-number-of-years": "104",
+    "model-realms": [
+        {
+            "id": "aer",
+            "is-required": true
+        },
+        {
+            "id": "aogcm",
+            "is-required": true
+        }
+    ],
+    "parent-experiment": [
+        "historical"
+    ],
+    "start-date": "none",
+    "tier": "1",
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/scen7-ln-aq.json
+++ b/experiment/scen7-ln-aq.json
@@ -1,0 +1,35 @@
+{
+    "id": "scen7-ln-aq",
+    "validation-key": "scen7-ln-AQ",
+    "ui-label": "Future scenario scen7-vlho with high aerosol and tropospheric non-methane ozone precursor emissions",
+    "description": "1. Detailed experiment configuration Future scenario scen7-vlhoc with higher aerosol and tropospheric non-methane ozone precursor emissions  2. Required model settings We encourage modelling centres to include as much atmospheric composition capability as possible. But, as a minimum, models should have tropospheric chemistry and interactive aerosols. And the experimental setup should be consistent with other scenario experiments.  3. Experiment conditions  4. Links to relevant references Fiedler et al. (in prep.) AerChemMIP2 - Unraveling the role of reactive gases, aerosols, and land use for air quality and climate change in CMIP7  5. Similarities to CMIP6 experiments none  6. Forcing differences from parent experiment Increased aerosol and ozone precursor emissions compared to parent.",
+    "activity": [
+        "aerchemmip"
+    ],
+    "alias": [],
+    "minimum-number-of-years": "104",
+    "model-realms": [
+        {
+            "id": "aer",
+            "is-required": true
+        },
+        {
+            "id": "aogcm",
+            "is-required": true
+        },
+        {
+            "id": "chem",
+            "is-required": true
+        }
+    ],
+    "parent-experiment": [
+        "historical"
+    ],
+    "start-date": "2022",
+    "tier": "1",
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/scen7-ln-ext.json
+++ b/experiment/scen7-ln-ext.json
@@ -1,0 +1,24 @@
+{
+    "id": "scen7-ln-ext",
+    "validation-key": "scen7-ln-ext",
+    "ui-label": "Very Low Concentration Driven Scenario Extension after High Overshoot",
+    "description": "Extension to Concentration driven scenario with similar end-of-century temperature impact to VLLO, but with less aggressive near-term mitigation and large reliance on net negative emissions, resulting in a higher overshoot.",
+    "activity": [
+        "scenariomip"
+    ],
+    "alias": [],
+    "end": 2500,
+    "min-number-yrs-per-sim": 50,
+    "model-realms": [],
+    "parent-experiment": [
+        "scen7-ln"
+    ],
+    "start": 2101,
+    "start-date": "none",
+    "tier": 0,
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/scen7-ln.json
+++ b/experiment/scen7-ln.json
@@ -1,0 +1,24 @@
+{
+    "id": "scen7-ln",
+    "validation-key": "scen7-ln",
+    "ui-label": "Very Low Concentration Driven Scenario after High Overshoot",
+    "description": "Concentration driven scenario with similar end-of-century temperature impact to VL, but with less aggressive near-term mitigation and large reliance on net negative emissions, resulting in a higher overshoot.",
+    "activity": [
+        "scenariomip"
+    ],
+    "alias": [],
+    "end": 2100,
+    "min-number-yrs-per-sim": 79,
+    "model-realms": [],
+    "parent-experiment": [
+        "historical"
+    ],
+    "start": 2022,
+    "start-date": "none",
+    "tier": 0,
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/scen7-m-ext.json
+++ b/experiment/scen7-m-ext.json
@@ -1,0 +1,24 @@
+{
+    "id": "scen7-m-ext",
+    "validation-key": "scen7-m-ext",
+    "ui-label": "Medium, Concentration Driven Scenario Extension",
+    "description": "Medium concentration driven emission scenario extension consistent with current policies",
+    "activity": [
+        "scenariomip"
+    ],
+    "alias": [],
+    "end": 2500,
+    "min-number-yrs-per-sim": 50,
+    "model-realms": [],
+    "parent-experiment": [
+        "scen7-m"
+    ],
+    "start": 2101,
+    "start-date": "none",
+    "tier": 0,
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/scen7-m.json
+++ b/experiment/scen7-m.json
@@ -1,0 +1,24 @@
+{
+    "id": "scen7-m",
+    "validation-key": "scen7-m",
+    "ui-label": "Medium, Concentration Driven Scenario",
+    "description": "Medium concentration driven emission scenario consistent with current policies",
+    "activity": [
+        "scenariomip"
+    ],
+    "alias": [],
+    "end": 2100,
+    "min-number-yrs-per-sim": 79,
+    "model-realms": [],
+    "parent-experiment": [
+        "historical"
+    ],
+    "start": 2022,
+    "start-date": "none",
+    "tier": 0,
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/scen7-ml-ext.json
+++ b/experiment/scen7-ml-ext.json
@@ -1,0 +1,24 @@
+{
+    "id": "scen7-ml-ext",
+    "validation-key": "scen7-ml-ext",
+    "ui-label": "Medium, Concentration Driven Scenario Extension",
+    "description": "Extension to concentration driven scenario with delayed increase in mitigation effort, insufficient to meet Paris Agreement objectives",
+    "activity": [
+        "scenariomip"
+    ],
+    "alias": [],
+    "end": 2500,
+    "min-number-yrs-per-sim": 50,
+    "model-realms": [],
+    "parent-experiment": [
+        "scen7-ml"
+    ],
+    "start": 2101,
+    "start-date": "none",
+    "tier": 0,
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/scen7-ml.json
+++ b/experiment/scen7-ml.json
@@ -1,0 +1,24 @@
+{
+    "id": "scen7-ml",
+    "validation-key": "scen7-ml",
+    "ui-label": "Medium, Concentration Driven Scenario",
+    "description": "Concentration driven scenario with delayed increase in mitigation effort, insufficient to meet Paris Agreement objectives",
+    "activity": [
+        "scenariomip"
+    ],
+    "alias": [],
+    "end": 2100,
+    "min-number-yrs-per-sim": 79,
+    "model-realms": [],
+    "parent-experiment": [
+        "historical"
+    ],
+    "start": 2022,
+    "start-date": "none",
+    "tier": 0,
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/scen7-vl-ext.json
+++ b/experiment/scen7-vl-ext.json
@@ -1,0 +1,24 @@
+{
+    "id": "scen7-vl-ext",
+    "validation-key": "scen7-vl-ext",
+    "ui-label": "Very Low, Concentration Driven Scenario Extension with Limited Overshoot",
+    "description": "Extension to Concentration driven scenario consistent with limiting warming to 1.5 degree C by 2100 AD with limited overshoot (as low as plausible) of 1.5 degree C",
+    "activity": [
+        "scenariomip"
+    ],
+    "alias": [],
+    "end": 2500,
+    "min-number-yrs-per-sim": 50,
+    "model-realms": [],
+    "parent-experiment": [
+        "scen7-vl"
+    ],
+    "start": 2101,
+    "start-date": "none",
+    "tier": 0,
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}

--- a/experiment/scen7-vl.json
+++ b/experiment/scen7-vl.json
@@ -1,0 +1,24 @@
+{
+    "id": "scen7-vl",
+    "validation-key": "scen7-vl",
+    "ui-label": "Very Low Concentration Driven Scenario with Limited Overshoot",
+    "description": "Concentration driven scenario consistent with limiting warming to 1.5 degree C by 2100 AD with limited overshoot (as low as plausible) of 1.5 degree C",
+    "activity": [
+        "scenariomip"
+    ],
+    "alias": [],
+    "end": 2100,
+    "min-number-yrs-per-sim": 79,
+    "model-realms": [],
+    "parent-experiment": [
+        "historical"
+    ],
+    "start": 2022,
+    "start-date": "none",
+    "tier": 0,
+    "@context": "_context_",
+    "type": [
+        "wcrp:experiment",
+        "cmip7"
+    ]
+}


### PR DESCRIPTION
This restores the ScenarioMIP experiments and those with similar naming

Changes compared to previous experiment definitions;
* the `c` for concentration driven has been removed, e.g. `scen7-hc` -> `scen7-h`
* `vlho` -> `ln` and `vllo` -> `vl` as noted [here](https://github.com/WCRP-CMIP/CMIP7-CVs/discussions/1#discussioncomment-14586444)

I think I've caught all the parent experiment information and descriptions here.

Note that experiment json files were *copied* from an old check out of this repository rather than altering from scratch so any structural changes in the mean time will not have been picked up.