### PR TITLE
Allow users to create issues without using a template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,2 +1,2 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links: []


### PR DESCRIPTION
@wolfiex can you allow this please? It's impossible for the templates to anticipate every possible issue.