### PR TITLE
CI: use default GITHUB_TOKEN in form processor (PAT-lapse fallback)

### DIFF
--- a/.github/workflows/process-registration-forms.yml
+++ b/.github/workflows/process-registration-forms.yml
@@ -28,11 +28,18 @@ jobs:
 
       - name: Process issue form
         env:
-          # PAT with
-          # Contents: Read and write
-          # Issues: Read and write
-          # Pull requests: Read and write
-          GITHUB_TOKEN: "${{ secrets.FORM_ACCESS_TOKEN }}"
+          # The workflow's own `permissions:` block already grants
+          # contents/issues/pull-requests write, so the built-in
+          # GITHUB_TOKEN is sufficient. A PAT (`FORM_ACCESS_TOKEN`) was
+          # used previously but it fails with HTTP 403
+          # "Resource not accessible by personal access token" whenever
+          # it expires, loses its SSO grant for WCRP-CMIP, or drops
+          # CMIP7-CVs from its selected-repo list -- producing silent
+          # registration-pipeline outages (see issue queue 2026-06-05+).
+          # Trade-off: PRs opened by GITHUB_TOKEN do not retrigger
+          # workflows by default; if registration PRs need automatic CI,
+          # use a `pull_request_target` workflow or a deploy-key push.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}
         run: >


### PR DESCRIPTION
## Problem

The `process-registration-forms.yml` workflow is failing on every new institution / institution-member registration with:

```
GitHubApiError: GitHub API POST /repos/WCRP-CMIP/CMIP7-CVs/git/refs failed: HTTP 403:
  {"message":"Resource not accessible by personal access token", ...}
```

Run: https://github.com/WCRP-CMIP/CMIP7-CVs/actions (run #9 on issue #425, plus all subsequent registration issues today)

That message is the signature of a fine-grained PAT that has expired, lost its SSO grant for the WCRP-CMIP org, or had CMIP7-CVs dropped from its selected-repo list. Only an org admin can rotate `FORM_ACCESS_TOKEN`, so the pipeline stays down until they do.

## Impact

Every institution registration filed today is stuck unprocessed, including #419 (POLITO), #420 (AU), #421 (TUC), #422 (UAF), #424 (UAF), #425 (AWI). At least 9 institutions are waiting on this pipeline to unblock EC-Earth's model-family registration (Essential-Model-Documentation#596) and AWI-ESM3's CMIP7 publication.

## Proposed fix

Replace `secrets.FORM_ACCESS_TOKEN` with the built-in `secrets.GITHUB_TOKEN`. The workflow already grants `contents: write`, `issues: write`, `pull-requests: write` at the workflow level, so the default token has every scope the form-processor needs. The only repo it writes to is the current one — `--wcrp-universe-url` only reads from `raw.githubusercontent.com` (no token required).

## Trade-off

PRs opened by `GITHUB_TOKEN` do not retrigger workflows by default (GitHub security feature). If the registration-PR pipeline relies on `ci.yaml` / `test-prod.yaml` running on the auto-opened PRs, you'd want either:

- `pull_request_target` on the dependent workflows, or
- a deploy-key push instead of `GITHUB_TOKEN` PR creation, or
- restore the PAT path once a rotated token is in place

If the auto-CI behaviour matters here, treat this PR as a temporary fallback to unstick the queue while the PAT gets rotated.

If the auto-CI behaviour does **not** matter (looks plausible from the workflow chain: the new PRs land on `esgvoc_dev`, not the main publish branches), this PR is the cleaner long-term fix because it eliminates the PAT-rotation maintenance burden.

Happy to amend with whichever direction you prefer.

cc @Ayoubnac1 @CMIP-IPO