### PR TITLE
feat(branded_variables): update CV to take into account the v1.2.2.4 …

### DIFF
--- a/branded_variable/bigthetao_tavg-u-hm-sea.json
+++ b/branded_variable/bigthetao_tavg-u-hm-sea.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "bigthetao_tavg-u-hm-sea",
+    "type": "known_branded_variable"
+}

--- a/branded_variable/fco2all_tavg-u-hxy-u.json
+++ b/branded_variable/fco2all_tavg-u-hxy-u.json
@@ -1,5 +1,5 @@
 {
     "@context": "000_context.jsonld",
-    "id": "thetao_tavg-ol-hm-sea",
+    "id": "fco2all_tavg-u-hxy-u",
     "type": "known_branded_variable"
 }

--- a/branded_variable/netAtmosLandCO2Flux_tavg-u-hxy-lnd.json
+++ b/branded_variable/netAtmosLandCO2Flux_tavg-u-hxy-lnd.json
@@ -1,5 +1,5 @@
 {
     "@context": "000_context.jsonld",
-    "id": "bigthetao_tavg-ol-hm-sea",
+    "id": "netAtmosLandCO2Flux_tavg-u-hxy-lnd",
     "type": "known_branded_variable"
 }

--- a/branded_variable/netatmoslandco2flux_tavg-u-hxy-lnd.json
+++ b/branded_variable/netatmoslandco2flux_tavg-u-hxy-lnd.json
@@ -1,5 +1,5 @@
 {
     "@context": "000_context.jsonld",
-    "id": "netAtmosLandCO2Flux_tavg-u-hxy-lnd",
+    "id": "netatmoslandco2flux_tavg-u-hxy-lnd",
     "type": "known_branded_variable"
 }

--- a/branded_variable/so_tavg-u-hm-sea.json
+++ b/branded_variable/so_tavg-u-hm-sea.json
@@ -1,5 +1,5 @@
 {
     "@context": "000_context.jsonld",
-    "id": "so_tavg-ol-hm-sea",
+    "id": "so_tavg-u-hm-sea",
     "type": "known_branded_variable"
 }

--- a/branded_variable/thetao_tavg-u-hm-sea.json
+++ b/branded_variable/thetao_tavg-u-hm-sea.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "thetao_tavg-u-hm-sea",
+    "type": "known_branded_variable"
+}


### PR DESCRIPTION
…version of the data_request

Changes from DR v1.2.2.3 -> v1.2.2.4:

  - Replace 3 ocean branded variables that changed vertical label from 'ol' to 'u': bigthetao_tavg-ol-hm-sea -> bigthetao_tavg-u-hm-sea so_tavg-ol-hm-sea -> so_tavg-u-hm-sea thetao_tavg-ol-hm-sea -> thetao_tavg-u-hm-sea

  - Add 2 new branded variables with new variable roots: fco2all_tavg-u-hxy-u (Carbon Mass Flux into Atmosphere Due to All CO2 Emissions) netAtmosLandCO2Flux_tavg-u-hxy-lnd (Net Flux of CO2 Between Atmosphere and Land)