### PR TITLE
Add source thin entry for AWI-ESM3-4-2-veg-HR

### DIFF
--- a/source/awi-esm3-4-2-veg-hr.json
+++ b/source/awi-esm3-4-2-veg-hr.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "awi-esm3-4-2-veg-hr",
+  "type": "model"
+}


### PR DESCRIPTION
Adds the CMIP7-CVs thin entry pointing at the EMD model registration for `AWI-ESM3-4-2-veg-HR`, mirroring the pattern from [#439](https://github.com/WCRP-CMIP/CMIP7-CVs/pull/439) (AWI institution thin entry) and the existing `cnrm_esm2_1e.json`.

Upstream: EMD#640 (`New Model: AWI-ESM3-4-2-veg-HR`) was merged 2026-06-11 15:02 UTC by @charliepascoe. Full Stage 4 model definition lives in EMD; CMIP7-CVs only needs the thin pointer so the wcrp_cmip7 ATTR004 / FILE001 checks for `source_id=AWI-ESM3-4-2-veg-HR` pass.

5-line file, follows the same shape as the existing entries. cc @ltroussellier @znichollscr — happy to defer to whoever wants to own this pattern long-term.